### PR TITLE
Fix image to array conversion for Pillow 8.3.0

### DIFF
--- a/smartcrop.py
+++ b/smartcrop.py
@@ -12,7 +12,8 @@ from PIL.ImageFilter import Kernel
 
 def saturation(image):
     r, g, b = image.split()
-    r, g, b = np.array(r, float), np.array(g, float), np.array(b, float)
+    r, g, b = np.array(r), np.array(g), np.array(b)
+    r, g, b = r.astype(float), g.astype(float), b.astype(float)
     maximum = np.maximum(np.maximum(r, g), b)  # [0; 255]
     minimum = np.minimum(np.minimum(r, g), b)  # [0; 255]
     s = (maximum + minimum) / 255  # [0.0; 1.0]
@@ -270,7 +271,8 @@ class SmartCrop(object):
 
     def detect_skin(self, cie_array, source_image):
         r, g, b = source_image.split()
-        r, g, b = np.array(r, float), np.array(g, float), np.array(b, float)
+        r, g, b = np.array(r), np.array(g), np.array(b)
+        r, g, b = r.astype(float), g.astype(float), b.astype(float)
         rd = np.ones_like(r) * -self.skin_color[0]
         gd = np.ones_like(g) * -self.skin_color[1]
         bd = np.ones_like(b) * -self.skin_color[2]


### PR DESCRIPTION
First of all, thank you for making this package!

I recently got an error running smartcrop, which I think is due to the latest update to Pillow (v8.3.0). The following doesn't work anymore:

```python
>>> import numpy as np
>>> from PIL import Image
>>> im = Image.open('image.jpg')
>>> np.array(im, float)
TypeError: __array__() takes 1 positional argument but 2 were given
```
but this does work:

```python
>>> np.array(im).astype(float)
```

This PR addresses this problem for the two occurrences in smartcrop.py.



