### PR TITLE
Fix Image.ANTIALIAS deprecation

### DIFF
--- a/smartcrop.py
+++ b/smartcrop.py
@@ -108,7 +108,7 @@ class SmartCrop(object):
                 int(math.ceil(image.size[0] / self.score_down_sample)),
                 int(math.ceil(image.size[1] / self.score_down_sample))
             ),
-            Image.ANTIALIAS)
+            Image.Resampling.LANCZOS)
 
         top_crop = None
         top_score = -sys.maxsize
@@ -157,7 +157,7 @@ class SmartCrop(object):
                 image = image.copy()
                 image.thumbnail(
                     (int(image.size[0] * prescale_size), int(image.size[1] * prescale_size)),
-                    Image.ANTIALIAS)
+                    Image.Resampling.LANCZOS)
                 crop_width = int(math.floor(crop_width * prescale_size))
                 crop_height = int(math.floor(crop_height * prescale_size))
             else:
@@ -395,7 +395,7 @@ def main():
         print(json.dumps(result))
 
     cropped_image = image.crop(box)
-    cropped_image.thumbnail((options.width, options.height), Image.ANTIALIAS)
+    cropped_image.thumbnail((options.width, options.height), Image.Resampling.LANCZOS)
     cropped_image.save(options.outputfile, 'JPEG', quality=90)
 
 

--- a/smartcrop_v0_2_1.py
+++ b/smartcrop_v0_2_1.py
@@ -150,7 +150,7 @@ class SmartCrop(object):
                 image.size[0] / self.score_down_sample,
                 image.size[1] / self.score_down_sample
             ),
-            Image.ANTIALIAS)
+            Image.Resampling.LANCZOS)
 
         if debug:
             score_output_image.save('debug/score_image.jpg')
@@ -216,7 +216,7 @@ class SmartCrop(object):
                 image = image.copy()
                 image.thumbnail(
                     (int(image.size[0] * prescale_size), int(image.size[1] * prescale_size)),
-                    Image.ANTIALIAS)
+                    Image.Resampling.LANCZOS)
                 crop_width = int(math.floor(crop_width * prescale_size))
                 crop_height = int(math.floor(crop_height * prescale_size))
             else:
@@ -337,7 +337,7 @@ def main():
 
     image = Image.open(options.inputfile)
     image2 = image.crop(box)
-    image2.thumbnail((options.width, options.height), Image.ANTIALIAS)
+    image2.thumbnail((options.width, options.height), Image.Resampling.LANCZOS)
     image2.save(options.outputfile, 'JPEG', quality=90)
 
 

--- a/tests/test_smartcrop.py
+++ b/tests/test_smartcrop.py
@@ -28,7 +28,7 @@ def test_square_thumbs(image, crop):
 
     if box != crop:
         img = img.crop(box)
-        img.thumbnail((500, 500), Image.ANTIALIAS)
+        img.thumbnail((500, 500), Image.Resampling.LANCZOS)
         img.save('thumb.jpg')
 
     assert box == crop


### PR DESCRIPTION
Pillow is in the process of migrating the `Image.ANTIALIAS` constant to `Image.Resampling.LANCZOS`, and is showing DeprecationWarnings when running `smartcrop.py`:
```bash
python smartcrop.py ./tests/images/travel-1.jpg /tmp/out.jpg
./smartcrop.py:160: DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
# repeated
```

This PR implements the suggested fix. Thanks for your help!