### PR TITLE
Fix saturation()

### DIFF
--- a/smartcrop/library.py
+++ b/smartcrop/library.py
@@ -16,9 +16,9 @@ def saturation(image) -> np.ndarray:
     minimum = np.minimum(np.minimum(r, g), b)  # [0; 255]
     s = (maximum + minimum) / 255  # [0.0; 1.0] pylint:disable=invalid-name
     d = (maximum - minimum) / 255  # [0.0; 1.0] pylint:disable=invalid-name    
-    s[maximum == minimum] = 1  # avoid division by zero
+    s[maximum == minimum] = 0.001  # avoid division by zero
     mask = s > 1
-    s[mask] = 2 - d[mask]
+    s[mask] = 2 - s[mask]
     return d / s  # [0.0; 1.0]
 
 


### PR DESCRIPTION
The `saturation()` function is kind wrong. First, if you look in [smartcrop.js](https://github.com/jwagner/smartcrop.js/blob/0e207ed910625f91b07d35865c71a9621a63ebdb/smartcrop.js#L577) the output depends on `s` value like so:

```
if s > 1:
    return d / (2 - s)
else:
    return d / s
```
So I have adapted it based on the original. Secondly, the part about avoiding zeros was not done correctly by me due to lack of deeper understanding. With a small value close to zero, everything will be safe.
