### PR TITLE
[optimizing] some minor improvements to scrore()

### DIFF
--- a/smartcrop/library.py
+++ b/smartcrop/library.py
@@ -302,24 +302,17 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
         }
         target_data = target_image.getdata()
         target_width, target_height = target_image.size
-
         down_sample = self.score_down_sample
-        inv_down_sample = 1 / down_sample
-        target_width_down_sample = target_width * down_sample
-        target_height_down_sample = target_height * down_sample
 
         _inv255 = 1 / 255
         _inv255_sq = _inv255 * _inv255
         _skin_bias = self.skin_bias * 255
         _saturation_bias = self.saturation_bias * 255
 
-        for y in range(0, target_height_down_sample, down_sample):
-            for x in range(0, target_width_down_sample, down_sample):
-                index = int(
-                    math.floor(y * inv_down_sample) * target_width +
-                    math.floor(x * inv_down_sample)
-                )
-                importance = self.importance(crop, x, y)
+        for y in range(0, target_height):
+            for x in range(0, target_width):
+                index = y * target_width + x
+                importance = self.importance(crop, x * down_sample, y * down_sample)
                 detail = target_data[index][1]
                 score['skin'] += (
                     target_data[index][0] * (detail + _skin_bias) * importance


### PR DESCRIPTION
**Simplified iteration:** The loop now iterates directly over the downscaled `target` dimensions instead of the upscaled `analyse_image` space. This removes the need for `math.floor` and the complex index calculation with flooring, which were surprisingly expensive.

**Hoisted division:** The division by 255 is moved outside the loop. The factor `_inv255_sq` is used for `skin` and `saturation` because these scores originally involved two sequential divisions by 255 per pixel.