### PR TITLE
[optimizing] drop separate scores for skin, detail and saturation

### DIFF
--- a/smartcrop/library.py
+++ b/smartcrop/library.py
@@ -349,4 +349,4 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
         )
         total = score / (w * h)
 
-        return {'total' : total}
+        return {'total': total}


### PR DESCRIPTION
__Elimination of unnecessary calculations__: Each `score` call computes separate scores for skin, detail and saturation, that then are combined into the `total score`. We can avoid that and factor summation out of `score` method into the one-time precomputation of score. 