### PR TITLE
implement boost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ result = cropper.crop(image, 300, 300, boosts=[
 print(result['top_crop'])
 ```
 
-Each `Boost` is a rectangle in the original image's pixel coordinates with a `weight` controlling its influence. Multiple boosts can be supplied and their weights accumulate in overlapping areas. `SmartCrop.boost_weight` (default `100.0`) scales all boost contributions globally.
+Each `Boost` is a rectangle in the original image's pixel coordinates with a `weight` controlling its influence, in the same units as the other scoring weights (`skin_weight=1.8`, `saturation_weight=0.3`). Multiple boosts can be supplied and their weights accumulate in overlapping areas.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ result = cropper.crop(image, 100, 100)
 print(json.dumps(result, indent=2))
 ```
 
+### Boost
+
+You can bias crop selection toward specific regions of interest (e.g. detected faces) by passing a list of `Boost` objects:
+
+``` python
+import smartcrop
+from PIL import Image
+
+image = Image.open("photo.jpg")
+cropper = smartcrop.SmartCrop()
+result = cropper.crop(image, 300, 300, boosts=[
+    smartcrop.Boost(x=120, y=40, width=80, height=80, weight=1.0),
+])
+print(result['top_crop'])
+```
+
+Each `Boost` is a rectangle in the original image's pixel coordinates with a `weight` controlling its influence. Multiple boosts can be supplied and their weights accumulate in overlapping areas. `SmartCrop.boost_weight` (default `100.0`) scales all boost contributions globally.
+
 ## Testing
 
 Install dependencies for testing, then call `pytest`:

--- a/smartcrop/__init__.py
+++ b/smartcrop/__init__.py
@@ -1,3 +1,3 @@
-from .library import SmartCrop
+from .library import Boost, SmartCrop
 
-__all__ = ['SmartCrop']
+__all__ = ['Boost', 'SmartCrop']

--- a/smartcrop/library.py
+++ b/smartcrop/library.py
@@ -37,7 +37,6 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
     skin_color: tuple[float, float, float] = DEFAULT_SKIN_COLOR
     skin_threshold: float = 0.8
     skin_weight: float = 1.8
-    boost_weight: float = 100.0
 
     def apply_boosts(
         self,
@@ -457,7 +456,7 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
         )
 
         if boost_map is not None:
-            precomputed += boost_map * self.boost_weight
+            precomputed += boost_map
 
         return precomputed
 

--- a/smartcrop/library.py
+++ b/smartcrop/library.py
@@ -9,6 +9,15 @@ from PIL.ImageFilter import Kernel
 DEFAULT_SKIN_COLOR = (0.78, 0.57, 0.44)
 
 
+@dataclass
+class Boost:
+    x: int
+    y: int
+    width: int
+    height: int
+    weight: float
+
+
 @dataclass(eq=False, slots=True)
 class SmartCrop:  # pylint:disable=too-many-instance-attributes
     detail_weight: float = 0.2
@@ -28,6 +37,28 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
     skin_color: tuple[float, float, float] = DEFAULT_SKIN_COLOR
     skin_threshold: float = 0.8
     skin_weight: float = 1.8
+    boost_weight: float = 100.0
+
+    def apply_boosts(
+        self,
+        boosts: list[Boost],
+        image_width: int,
+        image_height: int,
+    ) -> np.ndarray:
+        """
+        Paint boost regions into a float32 map of shape (height, width).
+        Each boost rectangle accumulates weight; values are not clamped so
+        that multiple overlapping boosts stack naturally.
+        """
+        boost_map = np.zeros((image_height, image_width), dtype=np.float32)
+        for boost in boosts:
+            x0 = max(0, boost.x)
+            y0 = max(0, boost.y)
+            x1 = min(image_width, boost.x + boost.width)
+            y1 = min(image_height, boost.y + boost.height)
+            if x1 > x0 and y1 > y0:
+                boost_map[y0:y1, x0:x1] += boost.weight
+        return boost_map
 
     def analyse(  # pylint:disable=too-many-arguments,too-many-locals
         self,
@@ -38,7 +69,8 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
         max_scale: float = 1,
         min_scale: float = 0.9,
         num_scale_steps: int = 2,
-        step: int = 8
+        step: int = 8,
+        boosts: list[Boost] | None = None,
     ) -> dict:
         """
         Analyze image and return some suggestions of crops (coordinates).
@@ -57,7 +89,15 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
             Image.Resampling.LANCZOS
         )
 
-        precomputed_features = self.precompute_features(downsampled_features)
+        boost_map: np.ndarray | None = None
+        if boosts:
+            full_boost_map = self.apply_boosts(boosts, image.size[0], image.size[1])
+            boost_pil = Image.fromarray(full_boost_map).resize(
+                downsampled_features.size, Image.Resampling.LANCZOS
+            )
+            boost_map = np.array(boost_pil, dtype=np.float32)
+
+        precomputed_features = self.precompute_features(downsampled_features, boost_map)
         features_sum = np.sum(precomputed_features)
         prescore = features_sum * self.outside_importance
 
@@ -104,7 +144,8 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
         max_scale: float = 1,
         min_scale: float = 0.9,
         num_scale_steps: int = 2,
-        step: int = 8
+        step: int = 8,
+        boosts: list[Boost] | None = None,
     ) -> dict:
         """
         Scale the image, analyze it, and suggest a crop. This is for sure
@@ -127,6 +168,17 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
                     Image.Resampling.LANCZOS)
                 crop_width = int(math.floor(crop_width * prescale_size))
                 crop_height = int(math.floor(crop_height * prescale_size))
+                if boosts:
+                    boosts = [
+                        Boost(
+                            x=int(b.x * prescale_size),
+                            y=int(b.y * prescale_size),
+                            width=int(b.width * prescale_size),
+                            height=int(b.height * prescale_size),
+                            weight=b.weight,
+                        )
+                        for b in boosts
+                    ]
             else:
                 prescale_size = 1
 
@@ -137,7 +189,9 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
             min_scale=min_scale,
             max_scale=max_scale,
             num_scale_steps=num_scale_steps,
-            step=step)
+            step=step,
+            boosts=boosts,
+        )
 
         for i in range(len(result['crops'])):
             crop = result['crops'][i]
@@ -377,7 +431,11 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
 
         return s + d
 
-    def precompute_features(self, features_image: Image.Image) -> np.ndarray:
+    def precompute_features(
+        self,
+        features_image: Image.Image,
+        boost_map: np.ndarray | None = None,
+    ) -> np.ndarray:
         """
         Apply scaling, biasing, and weighting transformations to image features.
         """
@@ -397,6 +455,9 @@ class SmartCrop:  # pylint:disable=too-many-instance-attributes
             detail * self.detail_weight +
             saturation * self.saturation_weight
         )
+
+        if boost_map is not None:
+            precomputed += boost_map * self.boost_weight
 
         return precomputed
 

--- a/tests/test_smartcrop.py
+++ b/tests/test_smartcrop.py
@@ -1,8 +1,9 @@
 import os
 
+import numpy as np
 import pytest
 from PIL import Image
-from smartcrop import SmartCrop
+from smartcrop import Boost, SmartCrop
 
 
 def load_image(name):
@@ -95,3 +96,91 @@ def test_crops_validation(num_scale_steps, step, min_scale, max_scale, expected_
 
         error_msg = str(exc_info.value)
         assert expected_error in error_msg
+
+
+def _make_image(width, height, left_color, right_color):
+    """Create an image with a left half and right half of distinct solid colors."""
+    img = Image.new('RGB', (width, height))
+    img.paste(Image.new('RGB', (width // 2, height), left_color), (0, 0))
+    img.paste(Image.new('RGB', (width - width // 2, height), right_color), (width // 2, 0))
+    return img
+
+
+def test_apply_boosts():
+    cropper = SmartCrop()
+
+    # Single boost covering only the left half
+    boost_map = cropper.apply_boosts(
+        [Boost(x=0, y=0, width=50, height=100, weight=1.0)],
+        image_width=100, image_height=100,
+    )
+    assert boost_map.shape == (100, 100)
+    assert np.all(boost_map[:, :50] == 1.0)
+    assert np.all(boost_map[:, 50:] == 0.0)
+
+    # Two overlapping boosts should accumulate
+    boost_map2 = cropper.apply_boosts(
+        [
+            Boost(x=0, y=0, width=60, height=100, weight=1.0),
+            Boost(x=40, y=0, width=60, height=100, weight=0.5),
+        ],
+        image_width=100, image_height=100,
+    )
+    assert np.all(boost_map2[:, :40] == 1.0)    # only first boost
+    assert np.all(boost_map2[:, 40:60] == 1.5)  # both boosts overlap
+    assert np.all(boost_map2[:, 60:] == 0.5)    # only second boost
+
+    # Out-of-bounds boost should be clipped silently
+    boost_map3 = cropper.apply_boosts(
+        [Boost(x=80, y=0, width=50, height=100, weight=1.0)],
+        image_width=100, image_height=100,
+    )
+    assert np.all(boost_map3[:, :80] == 0.0)
+    assert np.all(boost_map3[:, 80:] == 1.0)
+
+
+def test_boost_shifts_crop():
+    # 200x100 image: left=gray (low interest), right=vivid orange (high saturation)
+    # Without boost the algorithm naturally prefers the right (saturated) side.
+    # A strong boost on the left should pull the crop there.
+    img = _make_image(200, 100, left_color=(128, 128, 128), right_color=(255, 100, 0))
+    cropper = SmartCrop()
+
+    result_no_boost = cropper.crop(img, 100, 100)
+    x_no_boost = result_no_boost['top_crop']['x']
+
+    result_with_boost = cropper.crop(
+        img, 100, 100,
+        boosts=[Boost(x=0, y=0, width=100, height=100, weight=1.0)],
+    )
+    x_with_boost = result_with_boost['top_crop']['x']
+
+    assert x_with_boost < x_no_boost, (
+        f"Boost on the left should shift crop left: "
+        f"no_boost x={x_no_boost}, with_boost x={x_with_boost}"
+    )
+
+
+def test_boost_prescaling():
+    # 400x400 image triggers prescaling (scale=4, prescale_size≈0.278).
+    # Left=gray, right=vivid orange — algorithm naturally prefers right.
+    # Boost on the left in original coordinates; if prescaling works correctly
+    # the boost is scaled down alongside the image and shifts the crop left.
+    # If coordinates were NOT scaled the boost lands out-of-bounds and has no
+    # effect, leaving the crop on the naturally preferred right side.
+    img = _make_image(400, 400, left_color=(128, 128, 128), right_color=(255, 100, 0))
+    cropper = SmartCrop()
+
+    result_no_boost = cropper.crop(img, 100, 100)
+    x_no_boost = result_no_boost['top_crop']['x']
+
+    result_with_boost = cropper.crop(
+        img, 100, 100,
+        boosts=[Boost(x=0, y=0, width=200, height=400, weight=1.0)],
+    )
+    x_with_boost = result_with_boost['top_crop']['x']
+
+    assert x_with_boost < x_no_boost, (
+        f"Boost on left of prescaled image should shift crop left: "
+        f"no_boost x={x_no_boost}, with_boost x={x_with_boost}"
+    )


### PR DESCRIPTION
I came across this Python version of https://github.com/jwagner/smartcrop.js working on a different project. I already implemented boosting for the vendored version of this library in that project so I thought that I should contribute that implementation back here.

This PR adds a Boost dataclass (x, y, width, height, weight) that callers can pass to crop() and analyse() to bias crop selection toward regions of interest (e.g. detected faces).

Boost coordinates are prescaled alongside the image when prescaling fires. `boost_weight` (default 100.0) controls the global influence of boosts.